### PR TITLE
입력으로 공개 URL도 사용할 수 있도록 변경

### DIFF
--- a/everytime.py
+++ b/everytime.py
@@ -1,6 +1,7 @@
 from datetime import time
 import requests
 from urllib.parse import urlparse
+
 class Everytime:
     def __init__(self, path):
         url = urlparse(path)

--- a/everytime.py
+++ b/everytime.py
@@ -5,7 +5,7 @@ class Everytime:
     def __init__(self, path):
         url = urlparse(path)
         if url.netloc == "everytime.kr":
-            self.path = url.path.replace("/@", "");
+            self.path = url.path.replace("/@", "")
             return
         self.path = path
 

--- a/everytime.py
+++ b/everytime.py
@@ -1,7 +1,11 @@
 from datetime import time
 import requests
+import re
 class Everytime:
     def __init__(self, path):
+        if re.match('^(https:\/\/everytime.kr\/@)[A-Za-z\d]{0,}', path) != None:
+            self.path = re.search('@[a-zA-Z\\d]{0,}', path).group().replace("@", "");
+            return
         self.path = path
 
     def get_timetable(self):

--- a/everytime.py
+++ b/everytime.py
@@ -1,10 +1,11 @@
 from datetime import time
 import requests
-import re
+from urllib.parse import urlparse
 class Everytime:
     def __init__(self, path):
-        if re.match('^(https:\/\/everytime.kr\/@)[A-Za-z\d]{0,}', path) != None:
-            self.path = re.search('@[a-zA-Z\\d]{0,}', path).group().replace("@", "");
+        url = urlparse(path)
+        if url.netloc == "everytime.kr":
+            self.path = url.path.replace("/@", "");
             return
         self.path = path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 icalendar>=4.0.3
 BeautifulSoup4>=4.6.3
 requests>=2.20.1
-re>=2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 icalendar>=4.0.3
 BeautifulSoup4>=4.6.3
 requests>=2.20.1
+re>=2.2.1


### PR DESCRIPTION
현재 에브리타임 앱 상에서 URL 공유 버튼을 누르면 everytime 도메인이 포함된 문자열이 클립보드에 복사됩니다. `https://everytime.kr/@{identifier}`

저 URL 자체를 입력으로 사용하면 조금 더 사용하기 편리할 것 같습니다.
아래는 사용 예제입니다.

```bash
$ python every2cal.py --begin 2023-09-01 --end 2023-12-21
경로 : https://everytime.kr/@test1234
작업 완료!🙌
```

기존 동작도 작동합니다.
```bash
$ python every2cal.py --begin 2023-09-01 --end 2023-12-21
경로 : test1234
작업 완료!🙌
```